### PR TITLE
Add iterator to C++ header

### DIFF
--- a/eval/rublets-cpp.h
+++ b/eval/rublets-cpp.h
@@ -13,5 +13,6 @@
 #include <mutex>
 #include <functional>
 #include <numeric>
+#include <iterator>
 using namespace std;
 


### PR DESCRIPTION
This allows you to use C++ iterators since preprocessor directives like
# include are impossible in-channel.
