### PR TITLE
Allow sandbox_net_t_users to be optional in the config.

### DIFF
--- a/rublets.rb
+++ b/rublets.rb
@@ -34,8 +34,12 @@ Signal.trap("USR1") do
   end
 end
 
-sandbox_net_t_users = Configru.sandbox_net_t_users.map do |hostmask|
-  Regexp.new(hostmask)
+if !Configru.sandbox_net_t_users.nil?
+  sandbox_net_t_users = Configru.sandbox_net_t_users.map do |hostmask|
+    Regexp.new(hostmask)
+  end
+else
+  sandbox_net_t_users = []
 end
 
 #bot = Thread.new do


### PR DESCRIPTION
I did not want any users to be able to run network code from my
Rublets instance, so I did not include sandbox_net_t_users in my
rublets.yml file.  This caused an exception.  This patch will check
for the presence of sandbox_net_t_users in the config before map.
